### PR TITLE
Remove docs for deprecated helm2 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,11 @@ $ helm repo update
 ## Install Packages (stable)
 
 ```sh
-# Helm 2.x client
-$ helm install --name my-release nginx-stable/nginx-ingress [--version 0.4.1]
-
-# Helm 3.x client
 $ helm install my-release nginx-stable/nginx-ingress [--version 0.4.1]
 ```
 
 ## Install Packages (experimental)
 
 ```sh
-# Helm 2.x client
-$ helm install --name my-release nginx-edge/nginx-ingress --devel
-
-# Helm 3.x client
 $ helm install my-release nginx-edge/nginx-ingress --devel
 ```


### PR DESCRIPTION
Helm2 clients were already deprecated in:
*  https://github.com/nginxinc/kubernetes-ingress/commit/6d531e2f36942545a3452d56f26c649073d9c1b7