### PR TITLE
Update DoS link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ helm install my-release nginx-stable/nginx-appprotect-dos-arbitrator [--versio
 
 #### Documentation
 
-https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/
+https://github.com/nginxinc/nap-dos-arbitrator-helm-chart
 
 ### NGINX Management Suite
 


### PR DESCRIPTION
The documentation for DoS was pointing at the NGINX Ingress Controller docs.
I couldn't find any docs on the website for the chart so I'm changing the link to GitHub

